### PR TITLE
Bump version.junit5 from 5.10.3 to 5.11.0

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -176,7 +176,7 @@
       <version.jsr107>1.1.0</version.jsr107>
       <version.junit>4.13.2</version.junit>
       <version.junit.platform>1.10.3</version.junit.platform>
-      <version.junit5>5.10.3</version.junit5>
+      <version.junit5>5.11.0</version.junit5>
       <version.log4j>2.23.1</version.log4j>
       <version.lucene>9.9.2</version.lucene>
       <version.metainf-services>1.11</version.metainf-services>


### PR DESCRIPTION
Bumps `version.junit5` from 5.10.3 to 5.11.0.

Updates `org.junit.jupiter:junit-jupiter-api` from 5.10.3 to 5.11.0
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.10.3...r5.11.0)

Updates `org.junit.jupiter:junit-jupiter-engine` from 5.10.3 to 5.11.0
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.10.3...r5.11.0)

Updates `org.junit.vintage:junit-vintage-engine` from 5.10.3 to 5.11.0
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.10.3...r5.11.0)

Updates `org.junit.jupiter:junit-jupiter-params` from 5.10.3 to 5.11.0
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.10.3...r5.11.0)

---
updated-dependencies:
- dependency-name: org.junit.jupiter:junit-jupiter-api dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.junit.jupiter:junit-jupiter-engine dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.junit.vintage:junit-vintage-engine dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.junit.jupiter:junit-jupiter-params dependency-type: direct:production update-type: version-update:semver-minor ...